### PR TITLE
Fix docs about persistence of answers

### DIFF
--- a/_includes/manuals/1.11/3.2.2_installer_options.md
+++ b/_includes/manuals/1.11/3.2.2_installer_options.md
@@ -7,7 +7,7 @@ The precedence for settings is for those set by arguments to foreman-installer o
 
 Every parameter available in the installer can be set using command line arguments to `foreman-installer`.  Run `foreman-installer --help` for most options, or `foreman-installer --full-help` for a list of every available option.
 
-When running the installer, all arguments passed on the command line will be persisted by default to `/etc/foreman-installer/scenarios.d/foreman-answers.yaml` and used automatically on subsequent runs, without needing to specify those arguments again.  This persistence can be disabled with the `-b` option.
+When running the installer, all arguments passed on the command line will be persisted by default to `/etc/foreman-installer/scenarios.d/foreman-answers.yaml` and used automatically on subsequent runs, without needing to specify those arguments again.  This persistence can be disabled with the `-d` option.
 
 #### Interactive mode
 


### PR DESCRIPTION
Seems like docs are lying about `-b` option.
cause

```
foreman-installer -v -b
ERROR: Unrecognised option '-b'
```
